### PR TITLE
fix typo in basic/request-matching.mdx

### DIFF
--- a/docs/basics/request-matching.mdx
+++ b/docs/basics/request-matching.mdx
@@ -46,7 +46,7 @@ Provided an exact request URL string, only those request that strictly match tha
 
 ```js
 // Only "POST https://api.backend.dev/users" requests match this handler
-rest.post('https://api.backend.com/users', responseResolver)
+rest.post('https://api.backend.dev/users', responseResolver)
 
 // Given your application runs on "http://localhost:8080",
 // this request handler URL gets resolved to "http://localhost:8080/invoices"


### PR DESCRIPTION
The domain name in the code should be `api.backend.dev`.